### PR TITLE
Implement Kiosk mode

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -153,7 +153,11 @@ func (w Window) ShowBrowser(content string, browser Browser) (err error) {
 		err = errors.New("Failed showing window.")
 	}
 	return
+}
 
+// set_kiosk determines whether Kiosk mode (full screen) is enabled for the window.
+func (w Window) SetKiosk(enable bool) {
+	C.webui_set_kiosk(C.size_t(w), C._Bool(enable))
 }
 
 // Wait waits until all opened windows get closed.


### PR DESCRIPTION
Implements kiosk mode.

macOS arm is currently all I can test on. Kiosk mode is not working on this test machine. It also does not work with the V wrapper. But I remember that it worked on my linux main machine. Unfortunately I can't test if there is a regression that is platform independent. 