### PR TITLE
Fix text editor example

### DIFF
--- a/examples/text-editor/main.go
+++ b/examples/text-editor/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sqweek/dialog"
 	"github.com/webui-dev/go-webui"
 )
 
@@ -30,25 +29,23 @@ func Save(e webui.Event) any {
 
 func Open(e webui.Event) any {
 	fmt.Println("Open.")
-
-	filename, err := dialog.File().Load()
-
-	if err == dialog.Cancelled {
-		return ""
+	file := e.Data.String()
+	if file == "" {
+		e.Window.Run("webui.call('Open', prompt`File Location`)")
+		return nil
 	}
-
-	content, err := os.ReadFile(filename)
+	content, err := os.ReadFile(file)
 
 	if err != nil {
-		fmt.Println("Error reading file ", filename)
+		fmt.Println("Error reading file ", file)
 		fmt.Println("Error: ", err)
 		return nil
 	}
 
-	filePath = filename
+	filePath = file
 
 	e.Window.Run(fmt.Sprintf("addText('%s')", b64.StdEncoding.EncodeToString([]byte(content))))
-	e.Window.Run(fmt.Sprintf("SetFile('%s')", b64.StdEncoding.EncodeToString([]byte(filename))))
+	e.Window.Run(fmt.Sprintf("SetFile('%s')", b64.StdEncoding.EncodeToString([]byte(file))))
 
 	return nil
 }

--- a/examples/text-editor/main.go
+++ b/examples/text-editor/main.go
@@ -1,16 +1,11 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/webui-dev/go-webui"
 )
 
-var filePath string = ""
-
 func Close(_ webui.Event) any {
-	fmt.Println("Exit.")
+	println("Exit.")
 
 	webui.Exit()
 
@@ -18,42 +13,9 @@ func Close(_ webui.Event) any {
 
 }
 
-func Save(e webui.Event) any {
-	println("Save.")
-
-	os.WriteFile(filePath, []byte(e.Data), 0644)
-
-	return nil
-}
-
-func Open(e webui.Event) any {
-	fmt.Println("Open.")
-
-	file := e.Data.String()
-	if file == "" {
-		e.Window.Run("webui.call('Open', prompt`File Location`)")
-		return nil
-	}
-
-	content, err := os.ReadFile(file)
-	if err != nil {
-		fmt.Printf("Error reading file %s. %v\n", file, err)
-		return nil
-	}
-
-	e.Window.Run(fmt.Sprintf("addText('%s')", webui.Encode(string(content))))
-	e.Window.Run(fmt.Sprintf("SetFile('%s')", file))
-
-	filePath = file
-
-	return nil
-}
-
 func main() {
 	w := webui.NewWindow()
 
-	w.Bind("Open", Open)
-	w.Bind("Save", Save)
 	w.Bind("Close", Close)
 
 	w.Show("ui/MainWindow.html")

--- a/examples/text-editor/main.go
+++ b/examples/text-editor/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	b64 "encoding/base64"
 	"fmt"
 	"os"
 
@@ -29,23 +28,23 @@ func Save(e webui.Event) any {
 
 func Open(e webui.Event) any {
 	fmt.Println("Open.")
+
 	file := e.Data.String()
 	if file == "" {
 		e.Window.Run("webui.call('Open', prompt`File Location`)")
 		return nil
 	}
-	content, err := os.ReadFile(file)
 
+	content, err := os.ReadFile(file)
 	if err != nil {
-		fmt.Println("Error reading file ", file)
-		fmt.Println("Error: ", err)
+		fmt.Printf("Error reading file %s. %v\n", file, err)
 		return nil
 	}
 
-	filePath = file
+	e.Window.Run(fmt.Sprintf("addText('%s')", webui.Encode(string(content))))
+	e.Window.Run(fmt.Sprintf("SetFile('%s')", file))
 
-	e.Window.Run(fmt.Sprintf("addText('%s')", b64.StdEncoding.EncodeToString([]byte(content))))
-	e.Window.Run(fmt.Sprintf("SetFile('%s')", b64.StdEncoding.EncodeToString([]byte(file))))
+	filePath = file
 
 	return nil
 }

--- a/examples/text-editor/ui/MainWindow.html
+++ b/examples/text-editor/ui/MainWindow.html
@@ -4,20 +4,12 @@
         <meta charset="utf-8">
         <link rel="icon" type="image/png" href="img/icon.png" />
         <title>Text Editor in Go using WebUI</title>
+        <!-- WebUI Bridge (Virtual File) -->
+        <script src="/webui.js"></script>
         <link rel="stylesheet" href="css/style.css">
         <link rel="stylesheet" href="css/lucario.css">
         <link rel="stylesheet" href="css/codemirror.min.css">
         <link rel="stylesheet" href="css/all.min.css">
-
-        <!-- WebUI Bridge (Virtual File) -->
-        <script src="/webui.js"></script>
-
-        <script src="js/codemirror.min.js"></script>
-        <script src="js/xml.min.js"></script>
-        <script src="js/css.min.js"></script>
-        <script src="js/javascript.min.js"></script>
-        <script src="js/clike.min.js"></script>
-        <script src="js/python.min.js"></script>
     </head>
     <body>
         <div class="topbar"></div>
@@ -48,7 +40,12 @@
                 <p><a href="https://webui.me" target="_blank">webui.me</a> | (C)2023 Hassan Draga</p>
             </div>
         </div>
-        <script src="/webui.js"></script>
+        <script src="js/codemirror.min.js"></script>
+        <script src="js/xml.min.js"></script>
+        <script src="js/css.min.js"></script>
+        <script src="js/javascript.min.js"></script>
+        <script src="js/clike.min.js"></script>
+        <script src="js/python.min.js"></script>
         <script src="js/ui.js"></script>
     </body>
 </html>

--- a/examples/text-editor/ui/MainWindow.html
+++ b/examples/text-editor/ui/MainWindow.html
@@ -16,7 +16,7 @@
         <nav>
             <ul>
                 <li>
-                    <a id="Open"><i class="fas fa-folder-open"></i></a>
+                    <a onclick="OpenFile();"><i class="fas fa-folder-open"></i></a>
                 </li>
                 <li id="SaveLi" style="pointer-events: none; color: #7ca0df;">
                     <a onclick="SaveFile();"><i class="fa fa-floppy-disk"></i></a>

--- a/examples/text-editor/ui/js/ui.js
+++ b/examples/text-editor/ui/js/ui.js
@@ -3,6 +3,7 @@
 // Elements
 let About = document.getElementById("About");
 let aboutBox = document.getElementById("about-box");
+let fileHandle = null;
 
 // About show
 About.onclick = function() {
@@ -65,45 +66,38 @@ function addLine(text) {
 
 // Add full text to the editor
 function addText(text) {
-    codeMirrorInstance.setValue(atob(text));
+    codeMirrorInstance.setValue(text);
 
     const element = document.getElementById('SaveLi');
     element.style.color = '#ddecf9';
     element.style.pointerEvents = 'all';
 }
 
-// Save the file
-function SaveFile() {
+async function OpenFile() {
+    [fileHandle] = await showOpenFilePicker({ multiple: false });
+    const fileData = await fileHandle.getFile();
+
+    // Read File
+    const reader = new FileReader();
+    reader.onload = (e) => addText(e.target.result);
+    reader.readAsText(fileData);
+
+    // Set file title and language
+    document.title = fileData.name;
+    SetFileModeExtension(fileData.name.split('.').pop());
+}
+
+async function SaveFile() {
+    // Create a FileSystemWritableFileStream to write to
+    const writableStream = await fileHandle.createWritable();
     const content = codeMirrorInstance.getValue();
-    webui.call('Save', content);
+    await writableStream.write(content);
+
+    // Write to disk
+    await writableStream.close();
 }
 
 window.addEventListener("DOMContentLoaded", (event) => {
     // Load
     codeMirrorInstance.setSize("100%", "99%");
 });
-
-function getFileExtension(path) {
-    console.log('getFileExtension: ' + path);
-    return path.split('.').pop();
-}
-
-function getFileName(path) {
-    console.log('getFileName: ' + path);
-    return path.split(/[/\\]/).pop();
-}
-
-function changeWindowTitle(newTitle) {
-    document.title = newTitle;
-}
-
-// Set file title and language
-function SetFile(path_base64) {
-    const path = webui.decode(path_base64);
-    const Extension = getFileExtension(path);
-    const FileName = getFileName(path);
-    console.log('Extension: ' + path);
-    console.log('FileName: ' + path);
-    SetFileModeExtension(Extension);
-    changeWindowTitle(FileName);
-}

--- a/examples/text-editor/ui/js/ui.js
+++ b/examples/text-editor/ui/js/ui.js
@@ -65,7 +65,7 @@ function addLine(text) {
 
 // Add full text to the editor
 function addText(text) {
-    codeMirrorInstance.setValue(webui.decode(text));
+    codeMirrorInstance.setValue(atob(text));
 
     const element = document.getElementById('SaveLi');
     element.style.color = '#ddecf9';


### PR DESCRIPTION
Uses a simplified prompt for opening a file location (e.g. the V example does).

This removes the need to install the `"github.com/sqweek/dialog"` dependency and works around that the the dialog currently does not open from the callback. 
