### PR TITLE
Improve arg parsing, add generic `Bind` and `GetArg` function.

### DIFF
--- a/examples/call_go_from_js.go
+++ b/examples/call_go_from_js.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/webui-dev/go-webui"
+	ui "github.com/webui-dev/go-webui"
 )
 
 const doc = `<!DOCTYPE html>
@@ -50,8 +50,12 @@ const doc = `<!DOCTYPE html>
 
 // JavaScript:
 // webui.call('MyID_One', 'Hello');
-func myFunctionString(e webui.Event) any {
-	response := e.Data.String()
+func myFunctionString(e ui.Event) ui.Void {
+	response, err := e.String()
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 
 	fmt.Printf("myFunctionString: %s\n", response) // Hello
 
@@ -65,8 +69,8 @@ func myFunctionString(e webui.Event) any {
 
 // JavaScript:
 // webui.call('MyID_Two', 123456789);
-func myFunctionInteger(e webui.Event) any {
-	response := e.Data.Int()
+func myFunctionInteger(e ui.Event) ui.Void {
+	response, _ := ui.GetArg[int](e)
 
 	fmt.Printf("myFunctionInteger: %d\n", response) // 123456789
 
@@ -75,8 +79,8 @@ func myFunctionInteger(e webui.Event) any {
 
 // JavaScript:
 // webui.call('MyID_Three', true);
-func myFunctionBoolean(e webui.Event) any {
-	response := e.Data.Bool()
+func myFunctionBoolean(e ui.Event) ui.Void {
+	response, _ := ui.GetArg[bool](e)
 
 	fmt.Printf("myFunctionBoolean: %t\n", response) // true
 
@@ -85,27 +89,28 @@ func myFunctionBoolean(e webui.Event) any {
 
 // JavaScript:
 // const result = webui.call('MyID_Four', number);
-func myFunctionWithResponse(e webui.Event) any {
-	number := e.Data.Int() * 2
+func myFunctionWithResponse(e ui.Event) int {
+	number, _ := ui.GetArg[int](e)
 
-	fmt.Printf("myFunctionWithResponse: %d\n", number)
+	response := number * 2
+	fmt.Printf("myFunctionWithResponse: %d\n", response)
 
-	return number
+	return response
 }
 
 func main() {
 	// Create a new window.
-	w := webui.NewWindow()
+	w := ui.NewWindow()
 
 	// Bind go functions.
-	w.Bind("MyID_One", myFunctionString)
-	w.Bind("MyID_Two", myFunctionInteger)
-	w.Bind("MyID_Three", myFunctionBoolean)
-	w.Bind("MyID_Four", myFunctionWithResponse)
+	ui.Bind(w, "MyID_One", myFunctionString)
+	ui.Bind(w, "MyID_Two", myFunctionInteger)
+	ui.Bind(w, "MyID_Three", myFunctionBoolean)
+	ui.Bind(w, "MyID_Four", myFunctionWithResponse)
 
 	// Show html UI.
 	w.Show(doc)
 
 	// Wait until all windows get closed.
-	webui.Wait()
+	ui.Wait()
 }

--- a/examples/text-editor/main.go
+++ b/examples/text-editor/main.go
@@ -11,7 +11,7 @@ import (
 
 var filePath string = ""
 
-func Close(_ webui.Event) any {
+func Close(_ webui.Event) webui.Void {
 	fmt.Println("Exit.")
 
 	webui.Exit()
@@ -20,7 +20,7 @@ func Close(_ webui.Event) any {
 
 }
 
-func Save(e webui.Event) any {
+func Save(e webui.Event) webui.Void {
 	println("Save.")
 
 	os.WriteFile(filePath, []byte(e.Data), 0644)
@@ -28,13 +28,13 @@ func Save(e webui.Event) any {
 	return nil
 }
 
-func Open(e webui.Event) any {
+func Open(e webui.Event) webui.Void {
 	fmt.Println("Open.")
 
 	filename, err := dialog.File().Load()
 
 	if err == dialog.Cancelled {
-		return ""
+		return nil
 	}
 
 	content, err := os.ReadFile(filename)
@@ -56,9 +56,9 @@ func Open(e webui.Event) any {
 func main() {
 	w := webui.NewWindow()
 
-	w.Bind("Open", Open)
-	w.Bind("Save", Save)
-	w.Bind("Close", Close)
+	webui.Bind(w, "Open", Open)
+	webui.Bind(w, "Save", Save)
+	webui.Bind(w, "Close", Close)
 
 	w.Show("ui/MainWindow.html")
 

--- a/lib.go
+++ b/lib.go
@@ -18,9 +18,9 @@ package webui
 #cgo linux LDFLAGS: -Lwebui/webui-linux-gcc-x64 -lwebui-2-static -lpthread -lm
 
 #include <webui.h>
-extern void goWebuiEvent(size_t _window, size_t _event_type, char* _element, char* _data, size_t _event_number);
+extern void goWebuiEvent(size_t _window, size_t _event_type, char* _element, char* _data, size_t _size, size_t _event_number);
 static void go_webui_event_handler(webui_event_t* e) {
-	goWebuiEvent(e->window, e->event_type, e->element, e->data, e->event_number);
+	goWebuiEvent(e->window, e->event_type, e->element, e->data, e->size, e->event_number);
 }
 static size_t go_webui_bind(size_t win, const char* element) {
 	return webui_bind(win, element, go_webui_event_handler);
@@ -80,6 +80,7 @@ type Event struct {
 	EventType uint
 	Element   string
 	Data      Data
+	Size      uint
 }
 
 type ScriptOptions struct {
@@ -112,13 +113,14 @@ func NewWindowId() Window {
 // Private function that receives and handles webui events as go events
 //
 //export goWebuiEvent
-func goWebuiEvent(window C.size_t, _event_type C.size_t, _element *C.char, _data *C.char, _event_number C.size_t) {
+func goWebuiEvent(window C.size_t, _event_type C.size_t, _element *C.char, _data *C.char, _size C.size_t, _event_number C.size_t) {
 	// Create a new event struct
 	e := Event{
 		Window:    Window(window),
 		EventType: uint(_event_type),
 		Element:   C.GoString(_element),
 		Data:      Data(C.GoString(_data)),
+		Size:      uint(_size),
 	}
 	// Call user callback function
 	funcId := uint(C.webui_interface_get_bind_id(window, _element))

--- a/lib.go
+++ b/lib.go
@@ -319,3 +319,22 @@ func (e Event) Bool() (arg bool, err error) {
 	}
 	return
 }
+
+// GetArg parses the JavaScript argument into a Go data type.
+func GetArg[T any](e Event) (arg T, err error) {
+	if e.Size == 0 {
+		err = &noArgError{e.Element}
+	}
+	var ret T
+	switch p := any(&ret).(type) {
+	case *string:
+		*p, err = e.String()
+	case *int:
+		*p, err = e.Int()
+	case *bool:
+		*p, err = e.Bool()
+	default:
+		err = json.Unmarshal([]byte(e.Data), p)
+	}
+	return ret, nil
+}


### PR DESCRIPTION
- Improves event arg parsing
- Adds generics `GetArg` and `Bind` functions.
  Both are added as generic Functions (not Methods!). Trying again to implement them as generic methods quickly became a nut I didn't want to crack at the current state of Gos generics and my understanding of them.
  So I opted for making the methods generic at a later point and provide the benefits as functions for now.

<details>
<summary>
<b>GetArg Examples</b>
</summary>

```go
func myFunctionWithResponse(e ui.Event) int {
	number, _ := ui.GetArg[int](e)
	// number, _ := e.Int() // event method also possible
	
	// GetArg supports struct parsing
	// person, _ := ui.GetArg[Person](e) 
}
```


GetArg example - object arg to go struct parse:

```go
// parse_person.go
package main

import (
	"fmt"

	ui "github.com/webui-dev/go-webui"
)

const doc = `<html style="background: #654da9; color: #eee">
<head>
	<script src="webui.js"></script>
</head>
<body>
	<button onclick="callV()">Send Object</button>
	<script>
		async function callV() {
			const person = {
				name: "john",
				age: 30
			}
			await webui.call("test", JSON.stringify(person));
		}
	</script>
</body>
</html>`

type Person struct {
	Name string `json:"name"`
	Age  int    `json:"age"`
}

func test(e ui.Event) ui.Void {
	response, _ := ui.GetArg[Person](e)
	fmt.Printf("myFunctionString: %v\n", response)
	return nil
}

func main() {
	w := ui.NewWindow()
	ui.Bind(w, "test", test)
	w.Show(doc)
	ui.Wait()
}
```
```sh
go run parse_person.go
```
press <kbd>Send Object</kbd>
</details>

<details>
<summary>
<b>Bind Examples</b>
</summary>
  
Generic Bind function example - allows dynamic return types for improved type safety:

```go
func myFunctionBoolean(e ui.Event) ui.Void {
	response, _ := ui.GetArg[bool](e)
	fmt.Printf("myFunctionBoolean: %t\n", response)
	return nil
}

func myFunctionWithResponse(e ui.Event) int {
	number, _ := ui.GetArg[int](e)
	return number * 2
}

ui.Bind(w, "MyID_Three", myFunctionBoolean)
ui.Bind(w, "MyID_Four", myFunctionWithResponse)
```

Bind method is still possible - requires return type `any`:
```go
func myFunctionBoolean(e ui.Event) any {
	response, _ := ui.GetArg[bool](e)
	fmt.Printf("myFunctionBoolean: %t\n", response)
	return nil
}

func myFunctionWithResponse(e ui.Event) any {
	number, _ := ui.GetArg[int](e)
	return number * 2
}

w.Bind("MyID_Three", myFunctionBoolean)
w.Bind("MyID_Four", myFunctionWithResponse)
```
</details>