### PR TITLE
Add `serve_a_folder` example

### DIFF
--- a/examples/serve_a_folder/main.go
+++ b/examples/serve_a_folder/main.go
@@ -21,6 +21,9 @@ func events(e ui.Event) any {
 	} else if e.EventType == ui.Navigation {
 		target, _ := e.String()
 		println("Starting navigation to: ", target)
+		// Since we bind all events, following `href` links is blocked by WebUI.
+		// To control the navigation, we need to use `Navigate()`.
+		e.Window.Navigate(target)
 	}
 	return nil
 }

--- a/examples/serve_a_folder/main.go
+++ b/examples/serve_a_folder/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"time"
+
+	ui "github.com/webui-dev/go-webui"
+)
+
+const (
+	w  = ui.Window(1)
+	w2 = ui.Window(2)
+)
+
+func events(e ui.Event) any {
+	if e.EventType == ui.Connected {
+		println("Connected.")
+	} else if e.EventType == ui.Disconnected {
+		println("Disconnected.")
+	} else if e.EventType == ui.MouseClick {
+		println("Click.")
+	} else if e.EventType == ui.Navigation {
+		target, _ := e.String()
+		println("Starting navigation to: ", target)
+	}
+	return nil
+}
+
+func switchToSecondPage(e ui.Event) any {
+	e.Window.Show("second.html")
+	return nil
+}
+
+func showSecondWindow(e ui.Event) any {
+	w2.Show("second.html")
+	// Remove the Go Back button when showing the second page in another window.
+	// Wait max. 10 seconds until the window is recognized as shown.
+	for i := 0; i < 1000; i++ {
+		if w2.IsShown() {
+			break
+		}
+		// Slow down check interval to reduce load.
+		time.Sleep(10 * time.Millisecond)
+	}
+	if w2.IsShown() {
+		return nil
+	}
+	// Let the DOM load.
+	time.Sleep(50 * time.Millisecond)
+	// Remove `Go Back` button.
+	w2.Run("document.getElementById('go-back').remove();")
+
+	return nil
+}
+
+func exit(e ui.Event) any {
+	ui.Exit()
+	return nil
+}
+
+func main() {
+	w.NewWindow()
+
+	// Bind HTML elements to functions
+	w.Bind("switch-to-second-page", switchToSecondPage)
+	w.Bind("open-new-window", showSecondWindow)
+	w.Bind("exit", exit)
+	// Bind all events.
+	w.Bind("", events)
+
+	// Show the main window.
+	w.Show("index.html")
+
+	// Prepare the second window.
+	w2.NewWindow()
+	w2.Bind("exit", exit)
+
+	ui.SetRootFolder("ui")
+	ui.Wait()
+}

--- a/examples/serve_a_folder/ui/index.html
+++ b/examples/serve_a_folder/ui/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+	<head>
+		<title>WebUI - Serve a Folder Example</title>
+		<script src="webui.js"></script>
+		<style>
+			body {
+				background: linear-gradient(to left, #36265a, #654da9);
+				color: AliceBlue;
+				font: 16px sans-serif;
+				text-align: center;
+				margin-top: 30px;
+			}
+			button {
+				margin: 5px 0 10px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>WebUI - Serve a Folder Example</h1>
+		<br />
+		<div>
+			<p>Click on the link to switch the page</p>
+			<a href="second.html">Switch page link</a>
+		</div>
+		<div>
+			<p>Or click on the button to switch the page programmatically</p>
+			<button id="switch-to-second-page">Switch page programmatically</button>
+		</div>
+		<div>
+			<p>Open the second page in another window</p>
+			<button id="open-new-window">Open Second Window</button>
+		</div>
+	</body>
+</html>

--- a/examples/serve_a_folder/ui/second.html
+++ b/examples/serve_a_folder/ui/second.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+	<head>
+		<title>WebUI - Second Page</title>
+		<script src="webui.js"></script>
+		<style>
+			body {
+				background: linear-gradient(to left, #36265a, #654da9);
+				color: AliceBlue;
+				font: 16px sans-serif;
+				text-align: center;
+				margin-top: 30px;
+			}
+			button {
+				margin: 5px 0 10px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Second Page</h1>
+		<br />
+		<button id="go-back" onclick="location.href='index.html';">Go Back</button>
+		<button id="exit">Exit</button>
+	</body>
+</html>

--- a/lib.go
+++ b/lib.go
@@ -35,7 +35,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"time"
 	"unsafe"
 )
 
@@ -208,8 +207,6 @@ func (w Window) Destroy() {
 // Exit closes all open windows. `Wait()` will return (Break).
 func Exit() {
 	C.webui_exit()
-	// Quickfix segfault on `Exit` call when all Events where bound. E.g.: `w.Bind("", events)`
-	time.Sleep(1 * time.Millisecond)
 }
 
 // SetRootFolder sets the web-server root folder path for the window.

--- a/lib.go
+++ b/lib.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 	"unsafe"
 )
 
@@ -207,6 +208,8 @@ func (w Window) Destroy() {
 // Exit closes all open windows. `Wait()` will return (Break).
 func Exit() {
 	C.webui_exit()
+	// Quickfix segfault on `Exit` call when all Events where bound. E.g.: `w.Bind("", events)`
+	time.Sleep(1 * time.Millisecond)
 }
 
 // SetRootFolder sets the web-server root folder path for the window.


### PR DESCRIPTION
I think the changes can be merged as they are, as the example works well enough. 
But unfortunately, there were problems while working on it, which I list below:

1. Segfaults when calling `webui.Exit()` and all events were bound `w.Bind("", events)`.
   - It could be worked around by adding a sleep to the exit function, but should be further investigated. 
   - A simple way to trigger the issue is to set the sleep time in the exit function to `time.Sleep(0 * time.Millisecond)`, running the serve_a_folder example and using Exit. 

2. Not all events types reach the bind callback, e.g. mouse clicks. 
   - You can add `println("Event type: ", e.EventType)` as first line to the `events` function in `serve_a_folder/main.go` and try to click the buttons in the example to navigate the page, this should also trigger click events - as it does with the main repo and other wrappers. You can also add the print above to the `goWebuiEvent` in `lib.go#L143`, before sending the event to the callback. If you re-test, the event type works correctly there.

I worry that the reason is also related to WebUIs internal threads, similar to what we encountered with V recently - that things get unintentionally destroyed by Gos GC. 

@hassandraga, when your time is not to occupied, please tell me if you also encounter the issue on windows and if you have an idea how to approach this.