### PR TITLE
feat: add missing functions

### DIFF
--- a/v2/lib.go
+++ b/v2/lib.go
@@ -447,23 +447,3 @@ func GetArgAt[T any](e Event, idx uint) (arg T, err error) {
 	return
 }
 
-// Return return the response to JavaScript.
-func Return[T any](e Event, value T) (err error) {
-	cEvent := e.cStruct()
-
-	switch v := any(&value).(type) {
-	case string:
-		C.webui_return_string(cEvent, C.CString(v))
-	case int:
-		C.webui_return_int(cEvent, C.longlong(v))
-	case int32:
-		C.webui_return_int(cEvent, C.longlong(v))
-	case int64:
-		C.webui_return_int(cEvent, C.longlong(v))
-	case bool:
-		C.webui_return_bool(cEvent, C.bool_t(v))
-	default:
-		err = &returnError{e.Element, reflect.TypeOf(value).String()}
-	}
-	return
-}

--- a/v2/lib.go
+++ b/v2/lib.go
@@ -14,9 +14,6 @@ package webui
 #cgo CFLAGS: -Iwebui/include
 #include "webui.h"
 
-typedef bool bool_t;
-
-// for webui_bind
 extern void goWebuiEventHandler(webui_event_t* e);
 static size_t go_webui_bind(size_t win, const char* element) {
 	return webui_bind(win, element, goWebuiEventHandler);
@@ -281,7 +278,7 @@ func (w Window) GetUrl() string {
 
 // SetPublic allows a specific window address to be accessible from a public network
 func (w Window) SetPublic(name string, status bool) {
-	C.webui_set_public(C.size_t(w), C.bool_t(status))
+	C.webui_set_public(C.size_t(w), C._Bool(status))
 }
 
 // Navigate navigates to a specific URL

--- a/v2/lib.go
+++ b/v2/lib.go
@@ -13,7 +13,6 @@ package webui
 /*
 #cgo CFLAGS: -Iwebui/include
 #include "webui.h"
-
 extern void goWebuiEventHandler(webui_event_t* e);
 static size_t go_webui_bind(size_t win, const char* element) {
 	return webui_bind(win, element, goWebuiEventHandler);
@@ -373,10 +372,6 @@ func (e *getArgError) Error() string {
 	return fmt.Sprintf("Failed getting argument of type `%s` for `%s`. %v", e.typ, e.element, e.err)
 }
 
-func (e *returnError) Error() string {
-	return fmt.Sprintf("Failed returning the response of type `%s` for `%s`.", e.typ, e.element)
-}
-
 func (e Event) cStruct() *C.webui_event_t {
 	return &C.webui_event_t{
 		window:       C.size_t(e.Window),
@@ -443,4 +438,3 @@ func GetArgAt[T any](e Event, idx uint) (arg T, err error) {
 	arg = ret
 	return
 }
-

--- a/v2/lib.go
+++ b/v2/lib.go
@@ -93,11 +93,6 @@ type getArgError struct {
 	typ     string
 }
 
-type returnError struct {
-	element string
-	typ     string
-}
-
 // User Go Callback Functions list
 var funcList = make(map[Window]map[uint]func(Event) any)
 
@@ -275,27 +270,27 @@ func (w Window) GetUrl() string {
 	return C.GoString(C.webui_get_url(C.size_t(w)))
 }
 
-// SetPublic allows a specific window address to be accessible from a public network
+// SetPublic allows a specific window address to be accessible from a public network.
 func (w Window) SetPublic(name string, status bool) {
 	C.webui_set_public(C.size_t(w), C._Bool(status))
 }
 
-// Navigate navigates to a specific URL
+// Navigate navigates to a specific URL.
 func (w Window) Navigate(url string) {
 	C.webui_navigate(C.size_t(w), C.CString(url))
 }
 
-// Clean free all memory resources. Should be called only at the end.
+// Clean frees all memory resources. It should only be called at the end.
 func Clean() {
 	C.webui_clean()
 }
 
-// DeleteAllProfiles deletes all local web-browser profiles folder. It should called at the end.
+// DeleteAllProfiles deletes all local web-browser profile folders. It should only be called at the end.
 func DeleteAllProfiles() {
 	C.webui_delete_all_profiles()
 }
 
-// DeleteProfile deletes a specific window web-browser local folder profile.
+// DeleteProfile deletes the specified windows local web-browser profile folder.
 func (w Window) DeleteProfile() {
 	C.webui_delete_profile(C.size_t(w))
 }
@@ -315,11 +310,11 @@ func (w Window) SetPort(port uint) bool {
 	return bool(C.webui_set_port(C.size_t(w), C.size_t(port)))
 }
 
-// -- SSL/TLS -------------------------
+// == SSL/TLS ================================================================
 
-// Run sets the SSL/TLS certificate and the private key content, both in PEM
-// format. This works only with `webui-2-secure` library. If set empty WebUI
-// will generate a self-signed certificate.
+// SetTLSCertificate sets the SSL/TLS certificate and the private key content,
+// both in PEM format. This works only with the `webui-2-secure` library.
+// If set to empty, WebUI will generate a self-signed certificate.
 func SetTLSCertificate(certificate_pem string, private_key_pem string) {
 	C.webui_set_tls_certificate(C.CString(certificate_pem), C.CString(private_key_pem))
 }


### PR DESCRIPTION
This PR adds almost all the missing functions, excluding:
* the functions from the `webui.h`'s "Wrapper's Interface" section. I didn't find any documentation about them so I don't understand their purpose.
* the `webui_set_file_handler()` function since I couldn't find a nice way to map the registered Go callbacks.