### PR TITLE
Utilize Go's error return type for SetdefaultRootFolder

### DIFF
--- a/v2/lib.go
+++ b/v2/lib.go
@@ -222,10 +222,13 @@ func SetRootFolder(path string) {
 }
 
 // SetDefaultRootFolder sets the web-server root folder path for all windows.
-func SetDefaultRootFolder(path string) bool {
+func SetDefaultRootFolder(path string) (err error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
-	return bool(C.webui_set_default_root_folder(cpath))
+	if !C.webui_set_default_root_folder(cpath) {
+		err = errors.New("Failed setting the default root folder.")
+	}
+	return
 }
 
 // IsShown checks if the window it's still running.


### PR DESCRIPTION
@hassandraga 

I'd update this to be an error return type to use an approach that is more Go native.

Similar how below is already doing it:

https://github.com/webui-dev/go-webui/blob/321177789f1fb28156fa3a8f88b8c2e64c86c97c/v2/lib.go#L164-L171

https://github.com/webui-dev/go-webui/blob/321177789f1fb28156fa3a8f88b8c2e64c86c97c/v2/lib.go#L175-L182

https://github.com/webui-dev/go-webui/blob/321177789f1fb28156fa3a8f88b8c2e64c86c97c/v2/lib.go#L384-L388