### PR TITLE
Added GetPort method (closes #46)

### DIFF
--- a/v2/lib.go
+++ b/v2/lib.go
@@ -348,9 +348,6 @@ func (w Window) GetChildProcessID() uint64 {
 // GetPort returns the network port of the running window. If the window isn't
 // running, an error is returned.
 func (w Window) GetPort() (int, error) {
-	if !w.IsShown() {
-		return 0, errors.New("error: window is not running")
-	}
 	port := int(C.webui_get_port(C.size_t(w)))
 	if port == 0 {
 		return 0, errors.New("error: failed to get port")


### PR DESCRIPTION
I noted in the documentation that `GetPort()` only works *after* the Window is running (i.e. `Show()` has been called)... but, to be honest, I'm not sure that users will fully grasp this. One option is to return an error if `webui_get_port` returns 0. Thoughts?